### PR TITLE
Expose eigen header. No explaination for why it was hidden

### DIFF
--- a/pybind11.BUILD
+++ b/pybind11.BUILD
@@ -22,7 +22,6 @@ INCLUDES = [
 EXCLUDES = [
     # Deprecated file that just emits a warning
     "include/pybind11/common.h",
-    "include/pybind11/eigen.h",
 ]
 
 cc_library(


### PR DESCRIPTION
Is there any reason for eigen being hidden? No errors are being shown. I have this change in my mirror, and thought I would at least propose it upstream