### PR TITLE
Add macOS linker compatibility

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -39,9 +39,10 @@ def pybind_extension(
         name = name + ".so",
         copts = copts + PYBIND_COPTS + ["-fvisibility=hidden"],
         features = features + PYBIND_FEATURES,
-        linkopts = [
-            "-Wl,-Bsymbolic",
-        ],
+        linkopts = select({
+            "@pybind11//:darwin": ["-Wl"],
+            "//conditions:default": ["-Wl,-Bsymbolic"],
+        }),
         linkshared = 1,
         tags = tags + ["local", "manual"],
         deps = deps + PYBIND_DEPS,

--- a/pybind11.BUILD
+++ b/pybind11.BUILD
@@ -34,3 +34,9 @@ cc_library(
     includes = ["include"],
     deps = ["@local_config_python//:python_headers"],
 )
+
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
I'm no expert in either Skylark or linkers, but here goes ...

This removes the hardcoded link option -Bsymbolic which is specific to GNU's linker when running on macOS.

Cheers,
Chris