### PR TITLE
Allow users to pass in additional linkopts to pybind_extension

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -29,6 +29,7 @@ def pybind_extension(
         name,
         copts = [],
         features = [],
+        linkopts = [],
         tags = [],
         deps = [],
         **kwargs):
@@ -39,7 +40,7 @@ def pybind_extension(
         name = name + ".so",
         copts = copts + PYBIND_COPTS + ["-fvisibility=hidden"],
         features = features + PYBIND_FEATURES,
-        linkopts = [
+        linkopts = linkopts + [
             "-Wl,-Bsymbolic",
         ],
         linkshared = 1,


### PR DESCRIPTION
I want to statically link libstdc++ with the pybind extension and currently I can't because I can't pass in linker options.