### PR TITLE
Modified select statement to be based on platforms, not `cpu` flag

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -41,7 +41,7 @@ def pybind_extension(
         copts = copts + PYBIND_COPTS + ["-fvisibility=hidden"],
         features = features + PYBIND_FEATURES,
         linkopts = linkopts + select({
-            "@pybind11//:darwin": ["-Wl"],
+            "@pybind11//:osx": [],
             "//conditions:default": ["-Wl,-Bsymbolic"],
         }),
         linkshared = 1,

--- a/pybind11.BUILD
+++ b/pybind11.BUILD
@@ -1,4 +1,5 @@
 # pybind11 - Seamless operability between C++11 and Python.
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,7 +37,6 @@ cc_library(
 )
 
 config_setting(
-    name = "darwin",
-    values = {"cpu": "darwin"},
-    visibility = ["//visibility:public"],
+    name = "osx",
+    constraint_values = ["@platforms//os:osx"],
 )


### PR DESCRIPTION
See issue #3 for context

PR #10 appears to be using a deprecated method of detecting the platform that bazel is building for. Additionally, I'm not certain that `darwin` is a valid `cpu` option that can be detected automatically - my understanding was that `cpu` is for values like `x86` or `arm`, not `darwin` as darwin is an operating system.

Evidence:
[CPU flag documentation](https://docs.bazel.build/versions/master/user-manual.html#flag--cpu) (note the reference to CROSSTOOL): 
>This option specifies the target CPU architecture to be used for the compilation of binaries during the build.
>
>Note that a particular combination of crosstool version, compiler version, and target CPU is allowed only if it has been specified in the currently used CROSSTOOL file. 

[Examples of valid cpu options](https://docs.bazel.build/versions/master/configurable-attributes.html) (note `darwin` not listed)

[Explanation that platforms are preferred over cpu flag and CROSSTOOL and examples of how to use](https://blog.bazel.build/2019/02/11/configurable-builds-part-1.html)

This PR also removes the unneeded `-Wl` option on mac.
