### PR TITLE
Allow the python extension to be built by wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 Provided rules:
 
 - `pybind_extension`: Builds a python extension, automatically adding the
-  required build flags and pybind11 dependencies. It also defines a .so target
-  which can be manually built and copied. The arguments match a `py_extension`.
+  required build flags and pybind11 dependencies. It defines a `*.so` target
+  which can be included as a `data` dependency of a `py_*` target.
 - `pybind_library`: Builds a C++ library, automatically adding the required
   build flags and pybind11 dependencies. This library can then be used as a
   dependency of a `pybind_extension`. The arguments match a `cc_library`.
 - `pybind_library_test`: Builds a C++ test for a `pybind_library`. The arguments
-  match a cc_test.
+  match a `cc_test`.
 
 To test a `pybind_extension`, the most common approach is to write the test in
 python and use the standard `py_test` build rule.

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -24,7 +24,7 @@ PYBIND_DEPS = [
 
 # Builds a Python extension module using pybind11.
 # This can be directly used in python with the import statement.
-# This adds rules for a .so binary file, which must be built manually.
+# This adds rules for a .so binary file.
 def pybind_extension(
         name,
         copts = [],
@@ -45,7 +45,7 @@ def pybind_extension(
             "//conditions:default": ["-Wl,-Bsymbolic"],
         }),
         linkshared = 1,
-        tags = tags + ["local", "manual"],
+        tags = tags + ["local"],
         deps = deps + PYBIND_DEPS,
         **kwargs
     )


### PR DESCRIPTION
Right now, `pybind_extension` adds the `manual` tag to the underlying `cc_binary` rule. This tag prevents `bazel build //my/package/...` or `bazel build //my/package:all` from actually building the python extension. This behavior is unintuitive and removing the tag would greatly improve developer ergonomics and match the behavior that most people expect.