### PR TITLE
Support building against Python 3

### DIFF
--- a/python_configure.bzl
+++ b/python_configure.bzl
@@ -156,10 +156,14 @@ def _get_python_bin(repository_ctx):
     python_bin = repository_ctx.os.environ.get(_PYTHON_BIN_PATH)
     if python_bin != None:
         return python_bin
-    if repository_ctx.attr.python3:
-        python_bin_path = repository_ctx.which("python3")
-    else:
-        python_bin_path = repository_ctx.which("python")
+    if repository_ctx.attr.python_version == "3":
+        python_bin_path = repository.ctx.which("python3")
+    elif repository_ctx.attr.python_version == "2":
+        python_bin_path = repository.ctx.which("python2")
+    elif repository_ctx.attr.python_version == "default":
+        python_bin_path = repository.ctx.which("python")
+    else
+        _fail("Invalid python_version value, must be '2', '3', or 'default'.")
     if python_bin_path != None:
         return str(python_bin_path)
     _fail("Cannot find python in PATH, please make sure " +
@@ -325,7 +329,7 @@ python_configure = repository_rule(
         _PYTHON_LIB_PATH,
     ],
     attrs = {
-        "python3": attr.bool(default=False),
+        "python_version": attr.string(default="default"),
     },
 )
 """Detects and configures the local Python.
@@ -338,8 +342,10 @@ python_configure(name = "local_config_python")
 
 Args:
   name: A unique name for this workspace rule.
-  python3: If True, will build for Python 3, i.e. will build against the
-      installation corresponding to the binary returned by `which python3`.
-      By default (False), will build for whatever Python version is returned by
+  python_version: If set to "3", will build for Python 3, i.e. will build
+      against the installation corresponding to the binary returned by
+      `which python3`.
+      If set to "2", will build for Python 2 (`which python2`).
+      By default, will build for whatever Python version is returned by
       `which python`.
 """

--- a/python_configure.bzl
+++ b/python_configure.bzl
@@ -157,11 +157,11 @@ def _get_python_bin(repository_ctx):
     if python_bin != None:
         return python_bin
     if repository_ctx.attr.python_version == "3":
-        python_bin_path = repository.ctx.which("python3")
+        python_bin_path = repository_ctx.which("python3")
     elif repository_ctx.attr.python_version == "2":
-        python_bin_path = repository.ctx.which("python2")
+        python_bin_path = repository_ctx.which("python2")
     elif repository_ctx.attr.python_version == "default":
-        python_bin_path = repository.ctx.which("python")
+        python_bin_path = repository_ctx.which("python")
     else:
         _fail("Invalid python_version value, must be '2', '3', or 'default'.")
     if python_bin_path != None:

--- a/python_configure.bzl
+++ b/python_configure.bzl
@@ -162,7 +162,7 @@ def _get_python_bin(repository_ctx):
         python_bin_path = repository.ctx.which("python2")
     elif repository_ctx.attr.python_version == "default":
         python_bin_path = repository.ctx.which("python")
-    else
+    else:
         _fail("Invalid python_version value, must be '2', '3', or 'default'.")
     if python_bin_path != None:
         return str(python_bin_path)

--- a/python_configure.bzl
+++ b/python_configure.bzl
@@ -156,7 +156,10 @@ def _get_python_bin(repository_ctx):
     python_bin = repository_ctx.os.environ.get(_PYTHON_BIN_PATH)
     if python_bin != None:
         return python_bin
-    python_bin_path = repository_ctx.which("python")
+    if repository_ctx.attr.python3:
+        python_bin_path = repository_ctx.which("python3")
+    else:
+        python_bin_path = repository_ctx.which("python")
     if python_bin_path != None:
         return str(python_bin_path)
     _fail("Cannot find python in PATH, please make sure " +
@@ -321,6 +324,9 @@ python_configure = repository_rule(
         _PYTHON_BIN_PATH,
         _PYTHON_LIB_PATH,
     ],
+    attrs = {
+        "python3": attr.bool(default=False),
+    },
 )
 """Detects and configures the local Python.
 
@@ -332,4 +338,8 @@ python_configure(name = "local_config_python")
 
 Args:
   name: A unique name for this workspace rule.
+  python3: If True, will build for Python 3, i.e. will build against the
+      installation corresponding to the binary returned by `which python3`.
+      By default (False), will build for whatever Python version is returned by
+      `which python`.
 """


### PR DESCRIPTION
Add a `python3` boolean argument to `python_configure`. If set to True, the Python installation will be auto-detected by running `which python3`, so Python 3 will be used. If False (default), the Python installation will be detected with `which python`, which will use either Python 2 or Python 3 depending on what `python` points to (this is the old behavior).

Fixes https://github.com/pybind/pybind11_bazel/issues/16.