### PR TITLE
Add support for hermetic Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ Then, in your `BUILD` file:
 ```starlark
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 ```
+
+## Hermetic Python
+
+To configure `pybind11_bazel` for hermetic Python, `python_configure` can take
+the target providing the Python runtime as an argument:
+
+```starlark
+python_configure(
+  name = "local_config_python",
+  python_interpreter_target = "@python_interpreter//:python_bin",
+)
+```


### PR DESCRIPTION
Allow `python_configure` to use a Python interpreter that is provided by a Bazel target, similarly to other Python rules (e.g. [`pip_install`](https://github.com/bazelbuild/rules_python/tree/master/python/pip_install#setup-workspace)).