### PR TITLE
Additional Hermeticity changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ Then, in your `BUILD` file:
 ```starlark
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 ```
+
+## Hermetic Python
+
+To configure `pybind11_bazel` for hermetic Python, `python_configure` can take
+the target providing the Python runtime as an argument:
+
+```starlark
+python_configure(
+  name = "local_config_python",
+  python_interpreter_target = "@python_interpreter//:python_bin",
+)
+```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "pybind11_bazel")


### PR DESCRIPTION
Allows for `python_library_target`, ran format, and changes scripts to block strings (opposed to released lines)

Sorry for the multipart change, but this has been sitting in my queue since April last year- just noticing that we had an update.
@quval gave review here: https://github.com/quval/pybind11_bazel/pull/1

You may want to squash since tree got a little dirty.