### PR TITLE
Add include/pybind11/eigen/*.h to INCLUDES

### DIFF
--- a/pybind11.BUILD
+++ b/pybind11.BUILD
@@ -21,6 +21,7 @@ OPTIONS = select({
 INCLUDES = [
     "include/pybind11/*.h",
     "include/pybind11/detail/*.h",
+    "include/pybind11/eigen/*.h",
 ]
 
 EXCLUDES = [


### PR DESCRIPTION
The file 'include/pybind11/eigen.h' #include's "eigen/matrix.h". But pybind11.BUILD doesn't include eigen/matrix.h in the headers it exports, resulting in an error when attempting to use eigen from within pybind11. This adds the eigen-specific headers to the included headers.