### PR TITLE
Explicitly specify `-undefined dynamic_lookup`

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -50,7 +50,7 @@ def pybind_extension(
         features = features + PYBIND_FEATURES,
         linkopts = linkopts + select({
             "@pybind11//:msvc_compiler": [],
-            "@pybind11//:osx": [],
+            "@pybind11//:osx": ["-undefined", "dynamic_lookup"],
             "//conditions:default": ["-Wl,-Bsymbolic"],
         }),
         linkshared = 1,


### PR DESCRIPTION
Fixes https://github.com/pybind/pybind11_bazel/issues/57.