### PR TITLE
Propagate the testonly= attribute in the pybind_extension macro.

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -68,6 +68,7 @@ def pybind_extension(
         name = name + "_copy_so_to_pyd",
         src = name + ".so",
         out = name + ".pyd",
+        testonly = kwargs.get("testonly")
     )
 
     native.alias(


### PR DESCRIPTION
Motivation: Enable test-only pybind_extensions to depend on test-only targets.

Note: Tested manually, using git_override.