### PR TITLE
Forward kwargs to alias

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -68,7 +68,8 @@ def pybind_extension(
         name = name + "_copy_so_to_pyd",
         src = name + ".so",
         out = name + ".pyd",
-        testonly = kwargs.get("testonly")
+        testonly = kwargs.get("testonly"),
+        visibility = kwargs.get("visibility"),
     )
 
     native.alias(
@@ -77,7 +78,8 @@ def pybind_extension(
             "@platforms//os:windows": name + ".pyd",
             "//conditions:default": name + ".so",
         }),
-        **kwargs
+        testonly = kwargs.get("testonly"),
+        visibility = kwargs.get("visibility"),
     )
 
 # Builds a pybind11 compatible library. This can be linked to a pybind_extension.

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -77,6 +77,7 @@ def pybind_extension(
             "@platforms//os:windows": name + ".pyd",
             "//conditions:default": name + ".so",
         }),
+        **kwargs
     )
 
 # Builds a pybind11 compatible library. This can be linked to a pybind_extension.


### PR DESCRIPTION
In case, attributes such as the visibility are set, this is not available for the alias. Passing the `kwargs` to the `alias` as well should fix this.