### PR TITLE
Add -Wl,-z,undefs to linux links

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -68,7 +68,10 @@ def pybind_extension(
         linkopts = linkopts + select({
             "@platforms//os:osx": ["-undefined", "dynamic_lookup"],
             Label("@pybind11//:msvc_compiler"): [],
-            "//conditions:default": ["-Wl,-Bsymbolic"],
+            "//conditions:default": [
+                "-Wl,-Bsymbolic",
+                "-Wl,-z,undefs",
+            ],
         }),
         linkshared = 1,
         tags = tags,


### PR DESCRIPTION
If the user's toolchain / global settings imply -z,defs, this is necessary similar to the macOS flags to allow libpython symbols to be undefined