### PR TITLE
Bump rules_python version in example

### DIFF
--- a/examples/basic/MODULE.bazel
+++ b/examples/basic/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "rules_python", version = "0.33.2")
+bazel_dep(name = "rules_python", version = "0.34.0")
 bazel_dep(name = "pybind11_bazel")
 local_path_override(
     module_name = "pybind11_bazel",


### PR DESCRIPTION
This is not required since the local version is used