### PR TITLE
Bump pybind version to 2.13.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 # Bazel extensions for pybind11
 module(
     name = "pybind11_bazel",
-    version = "2.12.0",
+    version = "2.13.1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")


### PR DESCRIPTION
Latest release available is https://github.com/pybind/pybind11/releases/tag/v2.13.1 so let's make it available for bazel as well.