### PR TITLE
Revert "Add -Wl,-z,undefs to linux links"

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -68,10 +68,7 @@ def pybind_extension(
         linkopts = linkopts + select({
             "@platforms//os:osx": ["-undefined", "dynamic_lookup"],
             Label("@pybind11//:msvc_compiler"): [],
-            "//conditions:default": [
-                "-Wl,-Bsymbolic",
-                "-Wl,-z,undefs",
-            ],
+            "//conditions:default": ["-Wl,-Bsymbolic"],
         }),
         linkshared = 1,
         tags = tags,


### PR DESCRIPTION
Reverts pybind/pybind11_bazel#90 which introduced https://github.com/pybind/pybind11_bazel/issues/94 causing also issues for https://github.com/pybind/pybind11_abseil. The revert closes #94. 