### PR TITLE
Mark extension as reproducible if integrity is available

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     version = "2.13.6",
 )
 
+bazel_dep(name = "bazel_features", version = "1.20.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -19,23 +19,17 @@ def _internal_configure_extension_impl(module_ctx):
     # The pybind11_bazel version should typically just be the pybind11 version,
     # but can end with ".bzl.<N>" if the Bazel plumbing was updated separately.
     version = version.split(".bzl.")[0]
-    integrity = _INTEGRITIES.get(version)
     http_archive(
         name = "pybind11",
         build_file = "//:pybind11-BUILD.bazel",
         strip_prefix = "pybind11-%s" % version,
         url = "https://github.com/pybind/pybind11/archive/refs/tags/v%s.tar.gz" % version,
-        integrity = integrity,
+        integrity = _INTEGRITIES.get(version),
     )
 
-    metadata_kwargs = {}
     if bazel_features.external_deps.extension_metadata_has_reproducible:
-        metadata_kwargs["reproducible"] = integrity != None
+        return module_ctx.extension_metadata(reproducible = True)
 
-    return module_ctx.extension_metadata(
-        root_module_direct_deps = ["pybind11"],
-        root_module_direct_dev_deps = [],
-        **metadata_kwargs
-    )
+    return None
 
 internal_configure_extension = module_extension(implementation = _internal_configure_extension_impl)


### PR DESCRIPTION
Mark the extension as reproducible if we can find an integrity that matches the version requested.

This removes an unnecessary entry from the lockfiles of pybind11_bazel users in that case.