### PR TITLE
Support Windows `.pyd` targets for Python Wheel Packaging

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -76,18 +76,23 @@ def pybind_extension(
         **kwargs
     )
 
-    copy_file(
-        name = name + "_copy_so_to_pyd",
-        src = name + ".so",
-        out = name + ".pyd",
-        testonly = kwargs.get("testonly"),
-        visibility = kwargs.get("visibility"),
+    native.genrule(
+        name = name + "_generated.pyd",
+        srcs = [name + ".so"],
+        outs = [name + ".pyd"],
+        cmd = """
+        cp $< $@
+        """,
+        target_compatible_with = select({
+            "@platforms//os:windows": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
     )
 
     native.alias(
         name = name,
         actual = select({
-            "@platforms//os:windows": name + ".pyd",
+            "@platforms//os:windows": name + "_generated.pyd",
             "//conditions:default": name + ".so",
         }),
         testonly = kwargs.get("testonly"),


### PR DESCRIPTION
Hello! This PR provides extended support for projects which use `pybind11_bazel` to produce Python wheels. 

As a developer on [PyScreenReader](https://github.com/PyScreenReader/PyScreenReader), it was discovered that the current implementation of `pybind11_bazel` and its method of copying `.so` `pybind_extension`  to `.pyd` file formats using `copy_file` does not work for the `rules_python` `py_wheel` rule. The reason for this appears to be that the generated `.pyd` file is not a true target which can be referred to by the `py_wheel` rule, or the dependency resolution graph struggles with this generated file strategy. This seems to have resulted in no one in the community developing Windows-based Python packages using pybind11 and Bazel. 

Regardless, the solution here is to use a similar strategy mentioned in #74 which used a [genrule](https://github.com/tink-crypto/tink/blob/92d1a369540546c349599c43f3a1490185568c5e/python/tink/cc/pybind/BUILD.bazel#L270-L290) to create a valid target for the aliasing. 