### PR TITLE
Mark module extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     version = "3.0.0",
 )
 
+bazel_dep(name = "bazel_features", version = "1.36.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -1,5 +1,6 @@
 """Module extension for "configuring" pybind11_bazel."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 _INTEGRITIES = {
@@ -26,5 +27,10 @@ def _internal_configure_extension_impl(module_ctx):
         url = "https://github.com/pybind/pybind11/archive/refs/tags/v%s.tar.gz" % version,
         integrity = _INTEGRITIES.get(version),
     )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    else:
+        return None
 
 internal_configure_extension = module_extension(implementation = _internal_configure_extension_impl)


### PR DESCRIPTION
This avoids an unnecessary lockfile entry.