### PR TITLE
pybind11 3.0.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 # Bazel extensions for pybind11
 module(
     name = "pybind11_bazel",
-    version = "3.0.0",
+    version = "3.0.1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/internal_configure.bzl
+++ b/internal_configure.bzl
@@ -10,6 +10,7 @@ _INTEGRITIES = {
     "2.13.5": "sha256-seIJxCs6ntdNo+CyWk9M1HjYnV77tI8EsnffQn+vYlI=",
     "2.13.6": "sha256-4Iy4f0dz2pf6e18DXeh2OrxlbYfVdz5i9toFh9Hw7CA=",
     "3.0.0": "sha256-RTsaPismbDrp2ockEcrbbWk6wYBjvXMibZbPtwFaIAw=",
+    "3.0.1": "sha256-dBYz2nRrfHOLtx8YVPlXudpmC80tzmjXGUkDfwlp0Mo=",
 }
 
 def _internal_configure_extension_impl(module_ctx):


### PR DESCRIPTION
I see that [v3.0.0 for `pybind11_bazel`](https://github.com/pybind/pybind11_bazel/commit/e442ea9aa37ce10860ee720a6eda507a40782ddb) is committed a couple of months ago, but there is no release for it. Is something blocking to release v3?

I also see that [pybind11 v3.0.1 is released a month ago](https://github.com/pybind/pybind11/releases/tag/v3.0.1). So, by following the commit for v3.0.0, I made a PR for v3.0.1.

Could somebody make a release for the latest pybind11 (v3.0.1)? I see that @jiawen released the last version (v2.13.6), but he seems to have left Google. So, maybe, @comicfans or @Mizux can help us here?


